### PR TITLE
[docker] Remove default user for Kibana

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -29,14 +29,13 @@ if [ "$1" = 'kibana' ]; then
 		sed -e "s|__PROJECT__|$PROJECT_NAME|" -i /opt/kibana/src/ui/views/chrome.jade
         fi
 
-        if [ "$ELASTICSEARCH_USER" != "" ]; then
+        if [ "$ELASTICSEARCH_USER" != "" -a "$ELASTICSEARCH_PASSWORD" != "" ]; then
                 sed -e "s|^#elasticsearch.username:.*$|elasticsearch.username: \"$ELASTICSEARCH_USER\"|" -i /opt/kibana/config/kibana.yml
                 sed -e "s|^#elasticsearch.password:.*$|elasticsearch.password: \"$ELASTICSEARCH_PASSWORD\"|" -i /opt/kibana/config/kibana.yml
 	else
-                ELASTICSEARCH_USER="kibanaserver"
-                ELASTICSEARCH_PASSWORD="kibanaserver"
-                sed -e "s|^#elasticsearch.username:.*$|elasticsearch.username: \"$ELASTICSEARCH_USER\"|" -i /opt/kibana/config/kibana.yml
-                sed -e "s|^#elasticsearch.password:.*$|elasticsearch.password: \"$ELASTICSEARCH_PASSWORD\"|" -i /opt/kibana/config/kibana.yml
+                echo >&2 'error: ELASTICSEARCH_USER or/and ELASTICSEARCH_PASSWORD environment variables were not configured'
+                echo >&2 '  these two docker environment variables must be configured before running the container'
+                exit 1
         fi
 
         if [ "$SUPPORT_ADDRESS" != "" ]; then


### PR DESCRIPTION
In order to avoid security issues, this commits removes the default
user that is configured if the docker env variables related to the
user definition are not defined. Now, if those variables are not
defined, an error message will appear and the script will exit with
code 1.
