### PR TITLE
Redirect to URL when the Contact entry is clicked

### DIFF
--- a/src/ui/public/kbn_top_nav/kbn_top_nav.html
+++ b/src/ui/public/kbn_top_nav/kbn_top_nav.html
@@ -38,7 +38,7 @@
           <ul class="list-unstyled">
             <li ng-repeat="subitem in currentPanelsons[i]" class="ng-scope">
               <a ng-mouseover="showDescription(subitem)" ng-mouseleave="hideDescription()" class="kuiLink submenuitem"
-                tabindex="0" role="button" ng-click="redirectToPanel(subitem.panel_id)">{{subitem.name}}</a>
+                tabindex="0" role="button" ng-click="redirectToPanel(subitem.name, subitem.panel_id)">{{subitem.name}}</a>
             </li>
           </ul>
         </div>

--- a/src/ui/public/kibiter/menu/render_kibiter_menu.js
+++ b/src/ui/public/kibiter/menu/render_kibiter_menu.js
@@ -5,7 +5,7 @@ export function renderKibiterMenu($scope) {
 
     $scope.showInfo = (item) => {
         if (item.type === "entry") {
-            $scope.redirectToPanel(item.panel_id)
+            $scope.redirectToPanel(item.name, item.panel_id)
         } else if (item.type === "menu") {
             if ($scope.parentDashboard === item) {
                 closeSubmenu($scope)
@@ -25,8 +25,11 @@ export function renderKibiterMenu($scope) {
         $scope.showDescriptionDiv = false;
     }
 
-    $scope.redirectToPanel = (panel_id) => {
+    $scope.redirectToPanel = (name, panel_id) => {
         $scope.showKibiterMenu = false;
+        if (name === "Contact") {
+            window.location.replace(panel_id)
+        }
         window.location.replace(window.location.href.split("app/")[0] + "app/kibana#/dashboard/" + panel_id)
     }
 


### PR DESCRIPTION
The About item is now a submenu that has a link to the panel and
a link to the support repository, this is an absolute URL so this
commits changes the behavior of the click when the "Contact"
entry is clicked, redirecting the user to the URL instead
a panel.

Signed-off-by: David Moreno <dmorenolumb@gmail.com>

<!--
Thank you for your interest in and contributing to Kibana! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md)?
- If submitting code, have you included unit tests that cover the changes?
- If submitting code, have you tested and built your code locally prior to submission with `npm test && npm run build`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
-->
